### PR TITLE
feat: 감정 캘린더 및 리포트 API 리팩토링 및 서비스 분리

### DIFF
--- a/chatbot-backend/api/emo_calendar.py
+++ b/chatbot-backend/api/emo_calendar.py
@@ -1,10 +1,17 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from db.session import get_session
-from crud import get_emotions_by_date, update_emotion_calendar, get_strongest_emotions_by_month, create_emotion_calendar, delete_emotion_calendar, save_emotion_from_text
-from schemas import EmotionCalendarResponse, EmotionCalendarUpdateRequest, EmotionCalendarSummaryResponse, EmotionCalendarCreateRequest, EmotionCalendarFromTextRequest
+from schemas.emo_calendar import (
+    EmotionCalendarResponse, EmotionCalendarUpdateRequest,
+    EmotionCalendarSummaryResponse, EmotionCalendarCreateRequest,
+    EmotionCalendarFromTextRequest
+)
 from typing import List
 from datetime import date
+from services.emo_calendar_service import (
+    get_monthly_summary, get_daily_emotions, update_calendar_entry,
+    create_calendar_entry, delete_calendar_entry, create_calendar_from_text
+)
 
 router = APIRouter()
 
@@ -17,7 +24,13 @@ def read_monthly_emotions(
     month: int = Query(...),
     db: Session = Depends(get_session)
 ):
-    return get_strongest_emotions_by_month(db, member_seq, year, month)
+    """
+    월별 감정 요약 조회 API
+    - member_seq: 회원 시퀀스
+    - year, month: 조회할 연/월
+    - 반환: 일별로 가장 강한 감정을 가진 EmotionCalendarSummary 리스트
+    """
+    return get_monthly_summary(db, member_seq, year, month)
 
 
 # 2. 캘린더 상세페이지(해당 날짜 전체 게시물 불러오기)
@@ -27,7 +40,13 @@ def read_emo_calendar(
     calendar_date: date = Query(...),
     db: Session = Depends(get_session)
 ):
-    return get_emotions_by_date(db, member_seq, calendar_date)
+    """
+    특정 날짜의 감정 기록 전체 조회 API
+    - member_seq: 회원 시퀀스
+    - calendar_date: 조회할 날짜
+    - 반환: 해당 날짜의 EmotionCalendar 리스트
+    """
+    return get_daily_emotions(db, member_seq, calendar_date)
 
 
 # 3. 캘린더 내용 수정 (감정 캐릭터, 제목, 메모 등 변경)
@@ -37,21 +56,30 @@ def update_emo_calendar(
     update_data: EmotionCalendarUpdateRequest,
     db: Session = Depends(get_session)
 ):
-    updated = update_emotion_calendar(db, calendar_seq, update_data)
-    
+    """
+    감정 기록 수정 API
+    - calendar_seq: 수정할 감정 캘린더 항목의 시퀀스
+    - update_data: 제목, 메모, 감정 캐릭터 등의 수정 내용
+    - 반환: 성공 메시지 또는 404 에러
+    """
+    updated = update_calendar_entry(db, calendar_seq, update_data)
     if updated is None:
         raise HTTPException(status_code=404, detail="EmotionCalendar not found")
-
     return {"message": "Update successful", "calendar_seq": calendar_seq}
 
 
 # 4. 캘린더에 새로운 내용 입력 (사용자가 감정, 메모, 제목 직접 입력)
 @router.post("/")
-def create_calendar_entry(
+def create_calendar_entry_api(
     request: EmotionCalendarCreateRequest,
     db: Session = Depends(get_session)
 ):
-    result = create_emotion_calendar(db, request)
+    """
+    감정 기록 직접 작성 API
+    - request: 감정, 제목, 메모, 날짜 등의 데이터
+    - 반환: 생성된 calendar_seq 및 성공 메시지
+    """
+    result = create_calendar_entry(db, request)
     return {
         "calendar_seq": result.calendar_seq,
         "message": "감정 기록이 추가되었습니다."
@@ -60,26 +88,31 @@ def create_calendar_entry(
 
 # 5. 캘린더 내용 삭제  (calendar_seq 기준)
 @router.delete("/{calendar_seq}")
-def delete_calendar_entry(
+def delete_calendar_entry_api(
     calendar_seq: int,
     db: Session = Depends(get_session)
 ):
-    success = delete_emotion_calendar(db, calendar_seq)
-
+    """
+    감정 기록 삭제 API
+    - calendar_seq: 삭제할 감정 캘린더 항목의 시퀀스
+    - 반환: 성공 메시지 또는 404 에러
+    """
+    success = delete_calendar_entry(db, calendar_seq)
     if not success:
         raise HTTPException(status_code=404, detail="해당 게시글을 찾을 수 없습니다.")
-
     return {"message": "게시글이 성공적으로 삭제되었습니다."}
 
+
+
 @router.post("/from-text", response_model=EmotionCalendarResponse)
-def create_calendar_from_text(
+def create_calendar_from_text_api(
     request: EmotionCalendarFromTextRequest,
     db: Session = Depends(get_session)
 ):
-    return save_emotion_from_text(
-        db=db,
-        member_seq=request.member_seq,
-        calendar_date=request.calendar_date,
-        text=request.text,
-        title=request.title
-    )
+    """
+    텍스트 기반 감정 분석 후 감정 기록 생성 API
+    - request: raw_text, calendar_date, member_seq
+    - 내부에서 GPT API를 활용해 감정 분석 및 기록 생성
+    - 반환: 생성된 EmotionCalendar 데이터
+    """
+    return create_calendar_from_text(db, request)

--- a/chatbot-backend/api/emo_report.py
+++ b/chatbot-backend/api/emo_report.py
@@ -2,25 +2,13 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from db.session import get_session
 from schemas import EmotionReportResponse
-from crud import create_emotion_report, get_emotion_report
+from services.emo_report_service import create_emotion_report
+from crud.emo_report import get_emotion_report
 from datetime import date
 
 router = APIRouter()
 
-@router.post("/", response_model=EmotionReportResponse)
-def generate_report(
-    today: date,
-    member_seq: int,  # 실제 구현에서는 JWT에서 가져오는 것이 일반적
-    db: Session = Depends(get_session)
-):
-    """
-    월별 감정 요약 리포트를 생성합니다. (매월 1일 실행)
-    - 감정 비율 (파이차트용 JSON)
-    - GPT를 활용한 텍스트 요약
-    """
-    report = create_emotion_report(db, member_seq, today)
-    return report
-
+# 월간 감정 리포트 조회
 @router.get("/", response_model=EmotionReportResponse)
 def read_emotion_report(
     year: int = Query(..., ge=2000, le=2100, description="조회할 연도"),
@@ -28,14 +16,19 @@ def read_emotion_report(
     member_seq: int = Query(..., description="회원 시퀀스"),
     db: Session = Depends(get_session)
 ):
+    """
+    월간 감정 리포트 조회 API
+    - year, month: 조회할 연/월
+    - member_seq: 회원 시퀀스
+    - 반환: EmotionReportResponse
+    - 리포트가 없으면 404 에러 반환
+    """
     try:
         report_month = date(year, month, 1)
     except ValueError:
         raise HTTPException(status_code=400, detail="유효하지 않은 연도 또는 월입니다.")
 
     report = get_emotion_report(db, member_seq, report_month)
-
     if not report:
         raise HTTPException(status_code=404, detail="이 달의 리포트가 존재하지 않습니다.")
-
     return report

--- a/chatbot-backend/api/stt_api.py
+++ b/chatbot-backend/api/stt_api.py
@@ -11,7 +11,7 @@ import os
 
 
 # 라우터로 등록할 APIRouter 인스턴스 생성
-router = APIRouter(prefix="/stt")
+router = APIRouter()
 
 # 1. STT 토큰 확인
 @router.get("/token")

--- a/chatbot-backend/crud/__init__.py
+++ b/chatbot-backend/crud/__init__.py
@@ -8,5 +8,5 @@ from .emo_calendar import create_emotion_calendar
 from .emo_calendar import delete_emotion_calendar
 from .emo_calendar import save_emotion_from_text
 
-from .emo_report import create_emotion_report
+
 from .emo_report import get_emotion_report

--- a/chatbot-backend/crud/emo_report.py
+++ b/chatbot-backend/crud/emo_report.py
@@ -1,84 +1,73 @@
-from sqlalchemy.orm import Session
-from sqlalchemy import extract, func
-from models import EmotionCalendarDetail, EmotionCalendar, Emotion, EmotionReport
-from datetime import date, timedelta
-from typing import Dict
-import openai
-from utils import OPENAI_API_KEY
+from sqlalchemy.orm import Session, aliased
+from models.emotion_report import EmotionReport
+from models import EmotionCalendarDetail, EmotionCalendar, Emotion
+from datetime import date
 
-openai.api_key = OPENAI_API_KEY
+def get_emotion_report(db: Session, member_seq: int, report_date: date):
+    """
+    특정 회원의 특정 월(1일 기준) 감정 리포트를 조회합니다.
+    """
+    month_start = report_date.replace(day=1)
+    return db.query(EmotionReport).filter(
+        EmotionReport.member_seq == member_seq,
+        EmotionReport.report_date == month_start
+    ).first()
 
-# 감정 시퀀스를 영어 이름으로 매핑 (기본 감정 5개)
-emotion_mapping = {
-    '기쁨': 'joy',
-    '슬픔': 'sadness',
-    '분노': 'anger',
-    '불안': 'anxiety',
-    '평온': 'calm'
-}
+def save_emotion_report(db: Session, report: EmotionReport):
+    """
+    감정 리포트 객체를 DB에 저장하고, 갱신된 객체를 반환합니다.
+    """
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    return report
 
-# 전달 월의 감정 데이터를 계산하여 파이차트용 분포를 생성
-def calculate_emotion_distribution(db: Session, member_seq: int, target_month: date) -> Dict[str, float]:
-    # 전달의 시작과 끝 날짜
-    start_date = (target_month.replace(day=1) - timedelta(days=1)).replace(day=1)
-    end_date = target_month.replace(day=1) - timedelta(days=1)
+def get_monthly_emotion_stats(db: Session, member_seq: int, start_date: date, end_date: date):
+    """
+    전달 월의 감정별 (한글명, 강도, count) raw 데이터를 반환합니다.
+    
+    Parameters:
+    - db: SQLAlchemy 세션 객체
+    - member_seq: 회원 식별 번호
+    - start_date: 조회 시작일
+    - end_date: 조회 종료일
 
-    # 감정 캘린더와 디테일, 감정 테이블을 조인해서 감정별로 count
-    results = db.query(
-        Emotion.name_kr,
-        Emotion.emotion_intensity,
-        func.count().label("count")
-    ).join(EmotionCalendar, EmotionCalendar.calendar_seq == EmotionCalendarDetail.calendar_seq
-    ).join(Emotion, Emotion.emotion_seq == EmotionCalendarDetail.emotion_seq
-    ).filter(
-        EmotionCalendar.member_seq == member_seq,
-        EmotionCalendar.calendar_date >= start_date,
-        EmotionCalendar.calendar_date <= end_date
-    ).group_by(Emotion.name_kr, Emotion.emotion_intensity).all()
-
-    # 감정별 가중합 계산
-    score_sum = {}
-    total = 0
-
-    for name_kr, score, count in results:
-        eng_name = emotion_mapping.get(name_kr)
-        if eng_name:
-            weighted = score * count
-            score_sum[eng_name] = score_sum.get(eng_name, 0) + weighted
-            total += weighted
-
-    # 비율 계산 (전체 가중합 대비 각 감정의 비율)
-    distribution = {emotion: round(weight / total, 4) for emotion, weight in score_sum.items()}
-    return distribution
-
-# GPT API를 활용하여 전달 메모 내용을 요약
-def generate_monthly_summary(contexts: list[str]) -> str:
-    joined_text = "\n".join(contexts)
-    prompt = f"""
-    다음은 한 달간 사용자가 작성한 감정 메모입니다. 이 내용을 3~4문장으로 요약해 주세요.
-
-    {joined_text}
+    Returns:
+    - [(name_kr, emotion_intensity, count), ...] 형태의 리스트 반환
     """
 
-    response = openai.ChatCompletion.create(
-        model="gpt-4",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.7
-    )
+    from sqlalchemy import func  # 집계 함수를 사용하기 위해 func를 import
 
-    return response.choices[0].message['content']
+    try:
+        EmotionAlias = aliased(Emotion)
 
-# 전체 요약 처리
-def create_emotion_report(db: Session, member_seq: int, today: date):
-    target_month = today  # ex. 2025-06-01이면 5월 리포트
+        result = (
+            db.query(
+                EmotionAlias.name_kr,
+                EmotionAlias.emotion_intensity,
+                func.count().label("count")
+            )
+            .join(EmotionCalendarDetail, EmotionCalendarDetail.emotion_seq == EmotionAlias.emotion_seq)
+            .join(EmotionCalendar, EmotionCalendarDetail.calendar_seq == EmotionCalendar.calendar_seq)
+            .filter(
+                EmotionCalendar.member_seq == member_seq,
+                EmotionCalendar.calendar_date >= start_date,
+                EmotionCalendar.calendar_date <= end_date
+            )
+            .group_by(EmotionAlias.name_kr, EmotionAlias.emotion_intensity)
+            .all()
+        )
+        return result or []  # ← 쿼리 결과가 없으면 빈 리스트 반환
+    except Exception as e:
+        print(f"[ERROR] Failed to fetch emotion stats: {e}")
+        return []
 
-    # 1. 전달 감정 비율 계산
-    distribution = calculate_emotion_distribution(db, member_seq, target_month)
 
-    # 2. 전달 context 수집
-    start_date = (target_month.replace(day=1) - timedelta(days=1)).replace(day=1)
-    end_date = target_month.replace(day=1) - timedelta(days=1)
-
+def get_monthly_contexts(db: Session, member_seq: int, start_date: date, end_date: date):
+    """
+    전달 월의 감정 메모 context 리스트를 반환합니다.
+    - 반환: [context, ...]
+    """
     contexts = db.query(EmotionCalendarDetail.context
     ).join(EmotionCalendar, EmotionCalendar.calendar_seq == EmotionCalendarDetail.calendar_seq
     ).filter(
@@ -87,31 +76,129 @@ def create_emotion_report(db: Session, member_seq: int, today: date):
         EmotionCalendar.calendar_date <= end_date,
         EmotionCalendarDetail.context.isnot(None)
     ).all()
+    return [c[0] for c in contexts if c[0]]
 
-    context_texts = [c[0] for c in contexts if c[0]]
 
-    # 3. GPT 요약
-    summary_text = generate_monthly_summary(context_texts) if context_texts else None
+# from sqlalchemy.orm import Session
+# from sqlalchemy import extract, func
+# from models import EmotionCalendarDetail, EmotionCalendar, Emotion, EmotionReport
+# from datetime import date, timedelta
+# from typing import Dict
+# import openai
+# from utils import OPENAI_API_KEY
 
-    # 4. DB 저장
-    new_report = EmotionReport(
-        report_date=start_date,
-        emotion_distribution=distribution,
-        summary_text=summary_text,
-        created_at=today,
-        member_seq=member_seq
-    )
-    db.add(new_report)
-    db.commit()
-    db.refresh(new_report)
-    return new_report
+# openai.api_key = OPENAI_API_KEY
 
-# 특정 회원의 특정 달 리포트 조회 함수
-def get_emotion_report(db: Session, member_seq: int, report_month: date):
-    # report_month에서 해당 월의 1일로 맞추기 (예: 2025-05-15 → 2025-05-01)
-    month_start = report_month.replace(day=1)
+# # 감정 시퀀스를 영어 이름으로 매핑 (기본 감정 5개)
+# emotion_mapping = {
+#     '기쁨': 'joy',
+#     '슬픔': 'sadness',
+#     '분노': 'anger',
+#     '불안': 'anxiety',
+#     '평온': 'calm'
+# }
 
-    return db.query(EmotionReport).filter(
-        EmotionReport.member_seq == member_seq,
-        EmotionReport.report_date == month_start
-    ).first()
+# # 전달 월의 감정 데이터를 계산하여 파이차트용 분포를 생성
+# def calculate_emotion_distribution(db: Session, member_seq: int, target_month: date) -> Dict[str, float]:
+#     # 전달의 시작과 끝 날짜
+#     start_date = (target_month.replace(day=1) - timedelta(days=1)).replace(day=1)
+#     end_date = target_month.replace(day=1) - timedelta(days=1)
+
+#     # 감정 캘린더와 디테일, 감정 테이블을 조인해서 감정별로 count
+#     results = db.query(
+#         Emotion.name_kr,
+#         Emotion.emotion_intensity,
+#         func.count().label("count")
+#     ).join(EmotionCalendar, EmotionCalendar.calendar_seq == EmotionCalendarDetail.calendar_seq
+#     ).join(Emotion, Emotion.emotion_seq == EmotionCalendarDetail.emotion_seq
+#     ).filter(
+#         EmotionCalendar.member_seq == member_seq,
+#         EmotionCalendar.calendar_date >= start_date,
+#         EmotionCalendar.calendar_date <= end_date
+#     ).group_by(Emotion.name_kr, Emotion.emotion_intensity).all()
+
+#     # 감정별 가중합 계산
+#     score_sum = {}
+#     total = 0
+
+#     for name_kr, score, count in results:
+#         eng_name = emotion_mapping.get(name_kr)
+#         if eng_name:
+#             weighted = score * count
+#             score_sum[eng_name] = score_sum.get(eng_name, 0) + weighted
+#             total += weighted
+
+#     # 비율 계산 (전체 가중합 대비 각 감정의 비율)
+#     distribution = {emotion: round(weight / total, 4) for emotion, weight in score_sum.items()}
+#     return distribution
+
+# # GPT API를 활용하여 전달 메모 내용을 요약
+# def generate_monthly_summary(contexts: list[str]) -> str:
+#     joined_text = "\n".join(contexts)
+#     prompt = f"""
+#     당신의 역할은 감정 분석가입니다.
+#     다음은 사용자가 한 달 동안 작성한 감정 메모들입니다. 이 메모들을 바탕으로 사용자의 감정 흐름을 중심으로 3~4문장으로 요약해 주세요.
+
+#     - 주로 어떤 감정이 자주 나타났는지
+#     - 감정에 영향을 준 주요 사건 또는 상황이 있었는지
+#     - 전반적인 심리 상태는 어떤지
+#     - 위 내용에 대해 공감 및 피드백
+
+#     {joined_text}
+#     """
+
+#     response = openai.ChatCompletion.create(
+#         model="gpt-4",
+#         messages=[{"role": "user", "content": prompt}],
+#         temperature=0.7
+#     )
+
+#     return response.choices[0].message['content']
+
+# # 전체 요약 처리
+# def create_emotion_report(db: Session, member_seq: int, today: date):
+#     target_month = today  # ex. 2025-06-01이면 5월 리포트
+
+#     # 1. 전달 감정 비율 계산
+#     distribution = calculate_emotion_distribution(db, member_seq, target_month)
+
+#     # 2. 전달 context 수집
+#     start_date = (target_month.replace(day=1) - timedelta(days=1)).replace(day=1)
+#     end_date = target_month.replace(day=1) - timedelta(days=1)
+
+#     contexts = db.query(EmotionCalendarDetail.context
+#     ).join(EmotionCalendar, EmotionCalendar.calendar_seq == EmotionCalendarDetail.calendar_seq
+#     ).filter(
+#         EmotionCalendar.member_seq == member_seq,
+#         EmotionCalendar.calendar_date >= start_date,
+#         EmotionCalendar.calendar_date <= end_date,
+#         EmotionCalendarDetail.context.isnot(None)
+#     ).all()
+
+#     context_texts = [c[0] for c in contexts if c[0]]
+
+#     # 3. GPT 요약
+#     summary_text = generate_monthly_summary(context_texts) if context_texts else None
+
+#     # 4. DB 저장
+#     new_report = EmotionReport(
+#         report_date=start_date,
+#         emotion_distribution=distribution,
+#         summary_text=summary_text,
+#         created_at=today,
+#         member_seq=member_seq
+#     )
+#     db.add(new_report)
+#     db.commit()
+#     db.refresh(new_report)
+#     return new_report
+
+# # 특정 회원의 특정 달 리포트 조회 함수
+# def get_emotion_report(db: Session, member_seq: int, report_month: date):
+#     # report_month에서 해당 월의 1일로 맞추기 (예: 2025-05-15 → 2025-05-01)
+#     month_start = report_month.replace(day=1)
+
+#     return db.query(EmotionReport).filter(
+#         EmotionReport.member_seq == member_seq,
+#         EmotionReport.report_date == month_start
+#     ).first()

--- a/chatbot-backend/models/emotion_calendar_detail.py
+++ b/chatbot-backend/models/emotion_calendar_detail.py
@@ -12,7 +12,7 @@ class EmotionCalendarDetail(SQLModel, table=True):
 
     detail_seq: Optional[int] = Field(default=None, primary_key=True)
     emotion_score: int = Field(default=1)
-    source: SourceType = Field(description="user | ai")
+    source: SourceType = Field(nullable=False, description="user | ai")
     context: Optional[str] = Field(default=None)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     title: str = Field()

--- a/chatbot-backend/schemas/emo_calendar.py
+++ b/chatbot-backend/schemas/emo_calendar.py
@@ -6,10 +6,12 @@ class EmotionCalendarSummaryResponse(BaseModel):
     calendar_date: date
     character_image_url: str
 
-class EmotionCalendarResponse(BaseModel): # memo 삭제
+class EmotionCalendarResponse(BaseModel):
     character_image_url: str
     context: Optional[str]
     calendar_date: date
+
+    
 
 
 class EmotionCalendarUpdateRequest(BaseModel): # memo삭제
@@ -17,7 +19,6 @@ class EmotionCalendarUpdateRequest(BaseModel): # memo삭제
     context: Optional[str] = None
     title: Optional[str] = None
     emotion_seq: Optional[int] = None  # 감정 변경을 위한 필드
-    # emotion_score: Optional[int] = None  # 감정 강도 변경을 위한 필드 추가 ✅
 
 
 class EmotionCalendarCreateRequest(BaseModel): # memo삭제
@@ -26,7 +27,6 @@ class EmotionCalendarCreateRequest(BaseModel): # memo삭제
     title: str
     context: str
     emotion_seq: int
-    # emotion_score: int  # 1 or 2
 
 
 class EmotionCalendarFromTextRequest(BaseModel):

--- a/chatbot-backend/schemas/emo_report.py
+++ b/chatbot-backend/schemas/emo_report.py
@@ -7,7 +7,7 @@ class EmotionReportResponse(BaseModel):
     report_date: date  # 예: 2025-05-01 (5월 리포트)
     emotion_distribution: Dict[str, float]  # 감정별 비율
     summary_text: Optional[str] = None
-    created_at: Optional[datetime]
+    created_at: datetime
 
     class Config:
         orm_mode = True  # SQLModel -> Pydantic 자동 변환 허용

--- a/chatbot-backend/services/__init__.py
+++ b/chatbot-backend/services/__init__.py
@@ -1,0 +1,1 @@
+from .gpt import generate_monthly_summary

--- a/chatbot-backend/services/emo_calendar_service.py
+++ b/chatbot-backend/services/emo_calendar_service.py
@@ -1,0 +1,59 @@
+from sqlalchemy.orm import Session
+from crud.emo_calendar import (
+    get_strongest_emotions_by_month, get_emotions_by_date,
+    update_emotion_calendar, create_emotion_calendar, delete_emotion_calendar,
+    get_monthly_emotion_stats, get_monthly_contexts, save_emotion_from_text
+)
+from utils.emo_cal import calculate_emotion_distribution
+
+def get_monthly_summary(db: Session, member_seq: int, year: int, month: int):
+    """
+    월별 감정 캐릭터 요약(일별 가장 강한 감정 캐릭터)
+    """
+    return get_strongest_emotions_by_month(db, member_seq, year, month)
+
+def get_daily_emotions(db: Session, member_seq: int, calendar_date):
+    """
+    특정 날짜의 감정 기록 전체 반환
+    """
+    return get_emotions_by_date(db, member_seq, calendar_date)
+
+def update_calendar_entry(db: Session, calendar_seq: int, update_data):
+    """
+    감정 캘린더(및 디테일) 수정
+    """
+    return update_emotion_calendar(db, calendar_seq, update_data)
+
+def create_calendar_entry(db: Session, request):
+    """
+    감정 캘린더 및 디테일 새로 생성
+    """
+    return create_emotion_calendar(db, request)
+
+def delete_calendar_entry(db: Session, calendar_seq: int):
+    """
+    감정 캘린더 및 디테일 삭제
+    """
+    return delete_emotion_calendar(db, calendar_seq)
+
+def create_calendar_from_text(db: Session, request):
+    """
+    텍스트 기반 감정 분석 후 캘린더에 저장
+    """
+    return save_emotion_from_text(
+        db=db,
+        member_seq=request.member_seq,
+        calendar_date=request.calendar_date,
+        text=request.text,
+        title=request.title
+    )
+
+def get_monthly_emotion_distribution(db: Session, member_seq: int, year: int, month: int):
+    """
+    월별 감정 분포(파이차트용) 반환
+    """
+    from datetime import date, timedelta
+    start_date = date(year, month, 1)
+    end_date = (date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)) - timedelta(days=1)
+    stats = get_monthly_emotion_stats(db, member_seq, start_date, end_date)
+    return calculate_emotion_distribution(stats)

--- a/chatbot-backend/services/emo_report_service.py
+++ b/chatbot-backend/services/emo_report_service.py
@@ -1,0 +1,42 @@
+from sqlalchemy.orm import Session
+from crud.emo_report import (
+    get_emotion_report, save_emotion_report,
+    get_monthly_emotion_stats, get_monthly_contexts
+)
+from models.emotion_report import EmotionReport
+from datetime import date, timedelta
+from utils import calculate_emotion_distribution
+from services import generate_monthly_summary
+
+def create_emotion_report(db: Session, member_seq: int, today: date) -> EmotionReport:
+    """
+    월간 감정 리포트 생성(또는 이미 있으면 반환)
+    - 쿼리/계산/요약/저장 전체 담당
+    """
+    # 이미 리포트가 있으면 반환
+    existing = get_emotion_report(db, member_seq, today)
+    if existing:
+        return existing
+
+    # 전달 월의 시작/끝 날짜 계산
+    start_date = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+    end_date = today.replace(day=1) - timedelta(days=1)
+
+    # 1. 감정 raw 데이터 쿼리 → 비율 계산
+    stats = get_monthly_emotion_stats(db, member_seq, start_date, end_date)
+    emotion_distribution = calculate_emotion_distribution(stats)
+
+    # 2. 감정 메모 context 쿼리
+    context_texts = get_monthly_contexts(db, member_seq, start_date, end_date)
+
+    # 3. GPT 요약
+    summary_text = generate_monthly_summary(context_texts) if context_texts else None
+
+    # 4. DB 저장
+    report = EmotionReport(
+        member_seq=member_seq,
+        report_date=start_date,
+        emotion_distribution=emotion_distribution,
+        summary_text=summary_text
+    )
+    return save_emotion_report(db, report)

--- a/chatbot-backend/services/gpt.py
+++ b/chatbot-backend/services/gpt.py
@@ -1,4 +1,5 @@
 import openai
+import json
 from utils import OPENAI_API_KEY
 
 openai.api_key = OPENAI_API_KEY
@@ -6,16 +7,18 @@ openai.api_key = OPENAI_API_KEY
 # 감정 분석용 프롬프트 생성
 def generate_emotion_prompt(raw_text: str) -> str:
     return f"""
+    당신의 역할은 감정 분석가 입니다.
+
     다음 텍스트를 읽고 화자의 감정을 분석하세요.
     - 감정은 다음 중 하나여야 합니다:
     - joy (기쁨), sadness (슬픔), anger (분노), anxiety (불안), calm (평온)
     - 감정 강도는 1 (약함), 2 (보통), 3 (강함) 중 하나로 판단하세요.
 
     다음 JSON 형식으로 출력하세요:
-    {"emotion_name_en": "감정영문명", "emotion_intensity": 숫자}
+    {{"emotion_name_en": "감정영문명", "emotion_intensity": 숫자}}
 
     예시:
-    {"emotion_name_en": "joy", "emotion_intensity": 2}
+    {{"emotion_name_en": "joy", "emotion_intensity": 2}}
 
     텍스트:
     \"\"\"{raw_text}\"\"\"
@@ -29,14 +32,12 @@ def analyze_emotion_from_text(raw_text: str) -> dict:
         response = openai.ChatCompletion.create(
             model="gpt-4",
             messages=[
-                {"role": "system", "content": "당신의 역할은 감정 분석가입니다."},
-                {"role": "user", "content": prompt}],
+                {"role": "user", "content": prompt}
+            ],
             temperature=0.2
         )
 
         answer = response.choices[0].message["content"].strip()
-        # 문자열에서 JSON 파싱 시도
-        import json
         emotion_data = json.loads(answer)
         return emotion_data
 
@@ -46,3 +47,27 @@ def analyze_emotion_from_text(raw_text: str) -> dict:
             "emotion_name_en": "unknown",
             "emotion_intensity": 0
         }
+
+# GPT를 활용한 월간 감정 요약
+def generate_monthly_summary(contexts: list[str]) -> str:
+    joined_text = "\n".join(contexts)
+    prompt = f"""
+    당신의 역할은 감정 분석가입니다.
+    
+    다음은 사용자가 한 달 동안 작성한 감정 메모들입니다. 이 메모들을 바탕으로 사용자의 감정 흐름을 중심으로 3~4문장으로 요약해 주세요.
+
+    - 주로 어떤 감정이 자주 나타났는지
+    - 감정에 영향을 준 주요 사건 또는 상황이 있었는지
+    - 전반적인 심리 상태는 어떤지
+    - 위 내용에 대해 공감 및 피드백
+
+    {joined_text}
+    """
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.7
+    )
+
+    return response.choices[0].message['content']

--- a/chatbot-backend/utils/__init__.py
+++ b/chatbot-backend/utils/__init__.py
@@ -6,3 +6,5 @@ from .gpt import analyze_emotion_from_text
 from .vito_token_manager import get_new_token
 from .vito_token_manager import get_valid_token
 
+from .emo_cal import calculate_emotion_distribution
+

--- a/chatbot-backend/utils/emo_cal.py
+++ b/chatbot-backend/utils/emo_cal.py
@@ -1,0 +1,38 @@
+# 한글 감정명을 영어 감정명으로 매핑
+emotion_mapping = {
+    '기쁨': 'joy',
+    '슬픔': 'sadness',
+    '분노': 'anger',
+    '불안': 'anxiety',
+    '평온': 'calm'
+}
+
+def calculate_emotion_distribution(stats):
+    """
+    감정별 (name_kr, intensity, count) 리스트를 받아
+    영어 감정명 기준 비율 딕셔너리로 변환합니다.
+    - stats: [(name_kr, intensity, count), ...]
+    - 반환: {감정영문명: 비율(float)}
+    """
+    if not isinstance(stats, list) or not stats:
+        return {}
+
+    score_sum = {}
+    total = 0
+
+    for item in stats:
+        # 잘못된 데이터 방지
+        if not isinstance(item, (list, tuple)) or len(item) != 3:
+            continue
+
+        name_kr, score, count = item
+        eng_name = emotion_mapping.get(name_kr)
+        if eng_name and isinstance(score, (int, float)) and isinstance(count, int):
+            weighted = score * count
+            score_sum[eng_name] = score_sum.get(eng_name, 0) + weighted
+            total += weighted
+
+    if total == 0:
+        return {}
+
+    return {emotion: round(weight / total, 4) for emotion, weight in score_sum.items()}


### PR DESCRIPTION
- 감정 캘린더 관련 API를 서비스 레이어로 분리하여 코드 구조 개선
- 각 API에 대한 문서화 주석 추가
- CRUD 기능 및 감정 통계 관련 로직 개선
- STT API의 라우터 프리픽스 제거
- 감정 리포트 생성 및 조회 기능 개선
- 감정 분석 및 요약 기능을 위한 GPT 서비스 추가