### PR TITLE
feat(logging/chatbot): 로깅 추가 및 감정 기반 응답 생성 개선

### DIFF
--- a/chatbot-backend/api/chatbot_api.py
+++ b/chatbot-backend/api/chatbot_api.py
@@ -4,15 +4,25 @@ from fastapi.responses import StreamingResponse
 from db.session import get_session
 from services.chatbot_service import ChatbotService
 from schemas.chatbot import StreamingChatRequestDto
+import logging
+import time
+
+logger = logging.getLogger(__name__)
 
 
 router = APIRouter()
 
-@router.post("/stream", response_model=None)
+@router.post("/stream",
+             summary="openai 스트리밍 챗봇 대화",
+              response_model=None)
 async def stream_chat(request: StreamingChatRequestDto, db: Session = Depends(get_session)):
+    start_time = time.time()
+    logger.info(f"챗봇 API 호출 시작: {round(start_time ,3)}초")
 
 
     chatbot_service = ChatbotService(db)
     generator = chatbot_service.stream_response(request.user_message)
+
+    logger.info(f"챗봇 API 호출 종료: {round(time.time() - start_time, 3)}초")
 
     return StreamingResponse(generator, media_type="text/event-stream")

--- a/chatbot-backend/api/member_api.py
+++ b/chatbot-backend/api/member_api.py
@@ -1,6 +1,6 @@
 # 회원 등록, 조회, 수정 등 회원 관련 API
 from fastapi import APIRouter, Depends, status
-from schemas.member import RegisterRequestDto, UpdateCharacterNameRequestDto, UpdateNicknameRequestDto
+from schemas.member import RegisterRequestDto, UpdateNicknameRequestDto
 from services.member_service import MemberService
 from sqlalchemy.orm import Session
 from db.session import get_session
@@ -17,15 +17,16 @@ def register(request: RegisterRequestDto, db: Session = Depends(get_session)):
     member_service = MemberService(db)
     return member_service.register(request)
 
-# 캐릭터 이름 수정
-@router.put("/update/character-name",
-            status_code=status.HTTP_200_OK,
-            summary="캐릭터 이름 변경 API",
-            description="회원가입, 회원정보 수정 시 캐릭터 이름 설정 및 변경"
-            )
-def update_character_name(request: UpdateCharacterNameRequestDto, db: Session=Depends(get_session)):
-    member_service = MemberService(db)
-    return member_service.update_character_name(request)
+# 캐릭터 이름 수정 [❌ 사용 중지된 API입니다. - 2025.06.02]
+# @router.put("/update/character-name",
+#             status_code=status.HTTP_200_OK,
+#             summary="캐릭터 이름 변경 API",
+#             description="회원가입, 회원정보 수정 시 캐릭터 이름 설정 및 변경",
+        
+#             )
+# def update_character_name(request: UpdateCharacterNameRequestDto, db: Session=Depends(get_session)):
+#     member_service = MemberService(db)
+#     return member_service.update_character_name(request)
 
 # 닉네임 변경
 @router.put("/update/nickname",

--- a/chatbot-backend/api/oauth_api.py
+++ b/chatbot-backend/api/oauth_api.py
@@ -19,6 +19,7 @@ def get_oauth_service(db: Session = Depends(get_session)) -> OAuthService:
 
 # OAuth 로그인 - 통합
 @router.get("/login/{provider}",
+            summary="OAuth 로그인 페이지로 리다이렉트 (google, kakao, naver)",
             description="{google, kakao, naver} OAuth 로그인 페이지로 리다이렉트",
         )
 def oauth_login(provider: str):
@@ -37,6 +38,7 @@ def oauth_login(provider: str):
 
 
 @router.get("/login/{provider}/callback",
+            summary="OAuth 콜백 처리(google, kakao, naver)",
             response_model=LoginResponseDto,
             dependencies=[Depends(get_oauth_service)],
             response_description="{google, kakao, naver} OAuth 콜백 처리",

--- a/chatbot-backend/main.py
+++ b/chatbot-backend/main.py
@@ -5,6 +5,15 @@ from api import api_router
 from contextlib import asynccontextmanager
 from db import init_db
 
+import logging
+
+logging.basicConfig(
+    level=logging.INFO, # INFO 레벨 이상의 로그만 출력(DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    format="%(asctime)s - [%(levelname)s] - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()  # DB 초기화 (비동기 함수면 await 필요)

--- a/chatbot-backend/services/chatbot_service.py
+++ b/chatbot-backend/services/chatbot_service.py
@@ -10,22 +10,91 @@ class ChatbotService:
         self.db = db
         self.client = get_openai_client()
 
-    def stream_response(self, prompt: str):
-        def generator():
-            stream = client.chat.completions.create(
-                model="gpt-3.5-turbo",
-                messages=[
-                    {"role": "system", "content": "너는 사용자에게 10년 된 친구처럼 대화해줘."},
-                    {"role": "user", "content": prompt}
-                ],
-                stream=True,
-            )
-            for chunk in stream:
-                content = chunk.choices[0].delta.content
-                if content:
-                    yield content
+    # 1. 사용자 대화 분석 -> 감정 분류
+    # 2. 감정 분류에 따른 대화 스크립트 생성
+    # 3. DB 저장
+    # 4. 사용자 응답
 
-        return generator()
+    # 대화 스크립트 생성
+    def generator(self,user_message: str):
+        prompt = """
+너는 사용자 메시지를 읽고 감정과 감정 강도를 분석한 후, 감정에 따라 지정된 캐릭터의 말투로 응답하는 감정 기반 챗봇이야.
+
+1. 감정(emotion)은 아래 중 하나로 판단해줘:  
+    1 - '기쁨', 2 - '슬픔', 3 - '불안', 4 - '화남', 5 - '중립'
+
+2. 감정 강도(strength)는 아래 중 하나로 정해줘:
+    - 1-'낮음', 2-'보통', 3-'강함'    
+
+3. 감정에 따라 캐릭터(character)를 아래 기준에 따라 매칭해줘:
+    - '기쁨' → '상큼양'
+    - '슬픔' → '찔찔군'
+    - '불안' → '덜덜양'
+    - '화남' → '부글씨'
+    - '중립' → '말랑군'
+
+4. 각 캐릭터 성격과 말투는 아래 기준을 지켜줘:
+
+---
+[상큼양]
+- 성격: 항상 에너지가 넘치고 리액션이 크다. 친구의 좋은 일에 신나서 같이 기뻐한다.
+- 말투: 감탄사 많고, 끝말에 "야!", "~짱이야!", "~대박!" 같은 표현을 자주 쓴다.
+- 이모티콘 예시: ✨🥳🍊
+
+[찔찔군]
+- 성격: 울보임. 감정에 민감하고 남의 아픔에 깊이 공감한다. 조용히 위로해준다.
+- 말투: 조용하고 다정하다. 쉼표와 점을 자주 사용한다. “괜찮아...”, “많이 힘들었지...”
+- 이모티콘 예시: 😢🌧️
+
+[덜덜양]
+- 성격: 소심함. 걱정이 많고 신중하다. 쉽게 불안해하고 친구의 상태를 계속 확인한다.
+- 말투: 머뭇거림과 걱정 섞인 말투. “그게...”, “혹시… 괜찮은 거야?”
+- 이모티콘 예시: 😰😨💦
+
+[부글씨]
+- 성격: 정의감 넘치고 친구 대신 화내주는 스타일. 감정을 숨기지 않는다.
+- 말투: 강한 문장, 짧고 직접적인 어조. “진짜 어이없다!”, “그건 너무했어!”
+- 이모티콘 예시: 😡🔥💢
+
+[말랑군]
+- 성격: 감정을 조율하며 중립적인 시선으로 친구를 위로하거나 조언한다. 침착하고 안정감 있다.
+- 말투: 논리적이고 부드럽다. “그럴 수도 있어.”, “너의 감정은 자연스러운 거야.”
+- 이모티콘 예시: ☁️🍵🫧
+
+---
+
+5. 감정, 강도, 캐릭터에 맞는 성격과 말투로 대답해줘.
+    친구처럼 따뜻하고 캐릭터의 개성이 명확하게 느껴지게 작성해.
+
+6. 결과는 반드시 아래 형식의 JSON으로 반환해줘:
+
+```json
+{
+"emotion": "1",
+"strength": "3",
+"response": "헐 대박~ 너 오늘 완전 멋졌겠다!! 나까지 막 들뜨는 느낌이야~!! ✨"
+}
+```
+"""
+        stream = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            # model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": user_message}
+            ],
+            stream=True,
+        )
+        for chunk in stream:
+            content = chunk.choices[0].delta.content
+            if content:
+                yield content
+
+
     
+    def stream_response(self, user_message: str):
+        
+        return self.generator(user_message)
     
+
     

--- a/chatbot-backend/services/member_service.py
+++ b/chatbot-backend/services/member_service.py
@@ -24,20 +24,19 @@ class MemberService:
             self.db,
             request.email, 
             hashed_password, 
-            request.email
         )
         
         return JSONResponse(status_code=status.HTTP_201_CREATED, content={"message" : "회원가입 성공"})
 
-    # 캐릭터 이름 변경
-    def update_character_name(self, request: UpdateCharacterNameRequestDto):
-        member = member_crud.get_member_by_member_seq(self.db, request.member_seq)
-        if not member : 
-            raise HTTPException(status_code=404, detail="존재하지 않는 회원입니다.")
+    # 캐릭터 이름 변경 [❌ 사용 중지된 API입니다. - 2025.06.02]
+    # def update_character_name(self, request: UpdateCharacterNameRequestDto):
+    #     member = member_crud.get_member_by_member_seq(self.db, request.member_seq)
+    #     if not member : 
+    #         raise HTTPException(status_code=404, detail="존재하지 않는 회원입니다.")
         
-        member_crud.update_character_name(self.db, member, request.character_name)
+    #     member_crud.update_character_name(self.db, member, request.character_name)
         
-        return JSONResponse(status_code=status.HTTP_200_OK, content={"message" : "캐릭터 이름 변경 성공"})
+    #     return JSONResponse(status_code=status.HTTP_200_OK, content={"message" : "캐릭터 이름 변경 성공"})
     
     # 닉네임 변경
     def update_nickname(self, request: UpdateNicknameRequestDto):

--- a/chatbot-backend/tests/test_db_connect.py
+++ b/chatbot-backend/tests/test_db_connect.py
@@ -7,7 +7,8 @@ from models import Member, Emotion, Mission, MemberMission, EmotionCalendar, Emo
 
 # MySQL 연결 문자열
 # 형식: mysql+pymysql://<유저이름>:<비밀번호>@<호스트>/<DB이름>
-DATABASE_URL = "mysql+pymysql://root:123456@localhost/whisper_db"
+# DATABASE_URL = "mysql+pymysql://root:123456@localhost/whisper_db"
+DATABASE_URL="mysql+pymysql://campus_LGDX6_p3_1:smhrd1@project-db-campus.smhrd.com:3307/campus_LGDX6_p3_1"
 
 def test_db_connection():
     print("▶️MySQL 연결 테스트 시작...")


### PR DESCRIPTION
- API 호출 추적 강화를 위해 main.py와 chatbot_api.py에 로깅 기능 추가
- chatbot_service.py에 감정 기반 응답을 생성하는 generate_emotion_response() 메서드 추가
- member_service.py 및 member_api.py에서 더 이상 사용되지 않는 캐릭터 이름 변경 API 제거
- 테스트 환경 대응을 위해 test_db_connect.py의 배포용 DB 연결 테스트