### PR TITLE
fix(chatbot): chatbot history 오류 수정

### DIFF
--- a/chatbot-backend/models/member.py
+++ b/chatbot-backend/models/member.py
@@ -11,5 +11,5 @@ class Member(SQLModel, table=True):
     nickname: str = Field(max_length=100, nullable=False, description="닉네임")
     password: Optional[str] = Field(default=None, max_length=255, description="비밀번호")
     joined_at: datetime = Field(default_factory=lambda: datetime.now(UTC), description="가입일")
-    character_name : Optional[str] = Field(default="속닥이", max_length=50, description="캐릭터 이름")
+    # character_name : Optional[str] = Field(default="속닥이", max_length=50, description="캐릭터 이름")
     # profile_url: Optional[str] = Field(default=None, max_length=255, description="프로필 URL")

--- a/chatbot-backend/services/chatbot_service.py
+++ b/chatbot-backend/services/chatbot_service.py
@@ -131,7 +131,7 @@ class ChatbotService:
         prompt = [{"role": "system", "content": CHAT_PROMPT.format(emotion_name=emotion_name, strength=strength)}]
     
         for record in chat_history:
-            prompt.append({"role": "user", "content": f"{record.user_message} (감정: {record.emotion_name}, 강도: {record.emotion_strength}), 캐릭터: {record.character_name}"})
+            prompt.append({"role": "user", "content": f"{record.user_message} (감정: {EMOTION_NAME_MAP[record.emotion_seq]}, 강도: {STRENGTH_MAP[record.emotion_score]}), 캐릭터: {record.character_name}"})
             prompt.append({"role": "assistant", "content": f"{record.chatbot_response} ({record.character_name} 캐릭터 응답)"})
         
         prompt.append({"role": "user", "content": user_message})
@@ -152,7 +152,7 @@ class ChatbotService:
             logger.error(f"감정 분석 실패: {e}")
             raise HTTPException(status_code=500, detail="감정 분석 실패")
         
-        logger.info(f"🚨감정 분석 결과 : {emotion_response}")
+        logger.info(f"🚨최근 대화 내역 결과 : {chat_history}")
         # 3. 챗봇 응답 생성 string
         chatbot_prompt = self.build_chatbot_prompt(user_message, 
                                                                 chat_history, 


### PR DESCRIPTION
- 사용자 메시지의 감정 정보를 emotion_name, emotion_strength 변수명 에러 emotion_seq, emotion_score로 수정

- 사용하지 않는 필드인 Member 모델 내 character_name 주석처리